### PR TITLE
Support Win32-OpenSSH listing

### DIFF
--- a/corpus/win32-openssh.txt
+++ b/corpus/win32-openssh.txt
@@ -1,0 +1,5 @@
+-rw-******    1 -        -            2090 Nov  2 16:52 .bash_history
+-rw-******    1 -        -              54 Oct 29 16:07 .minttyrc
+drwx******    1 -        -            4096 Nov  2 14:17 .ssh
+-rw-******    1 -        -               0 Nov  2 10:00 .tig_history
+-rw-******    1 -        -             890 Nov  2 14:42 .viminfo

--- a/lib/File/Listing.pm
+++ b/lib/File/Listing.pm
@@ -56,6 +56,7 @@ sub file_mode ($)
     while (/(.)/g) {
         $mode <<= 1;
         $mode |= 1 if $1 ne "-" &&
+                      $1 ne "*" &&
                       $1 ne 'S' &&
                       $1 ne 'T';
     }
@@ -151,7 +152,7 @@ sub line
 
     my ($kind, $size, $date, $name);
     if (($kind, $size, $date, $name) =
-        /^([\-FlrwxsStTdD]{10})                   # Type and permission bits
+        /^([\-\*FlrwxsStTdD]{10})                 # Type and permission bits
          .*                                       # Graps
          \D(\d+)                                  # File size
          \s+                                      # Some space

--- a/t/file_listing.t
+++ b/t/file_listing.t
@@ -251,10 +251,15 @@ subtest 'win32-openssh' => sub {
   my %actual = map { $_->[0] => $_ } parse_dir($txt, undef);
 
   subtest 'dir' => sub {
-    is_deeply $actual{'.ssh'}, ['.ssh','d',undef,'1604323020','16832'];
+    is $actual{'.ssh'}->[0], '.ssh';
+    is $actual{'.ssh'}->[1], 'd';
+    is $actual{'.ssh'}->[4], '16832';
   };
   subtest 'file' => sub {
-    is_deeply $actual{'.bash_history'}, ['.bash_history','f','2090','1604332320','33152'];
+    is $actual{'.bash_history'}->[0], '.bash_history';
+    is $actual{'.bash_history'}->[1], 'f';
+    is $actual{'.bash_history'}->[2], '2090';
+    is $actual{'.bash_history'}->[4], '33152';
   };
 };
 

--- a/t/file_listing.t
+++ b/t/file_listing.t
@@ -253,12 +253,14 @@ subtest 'win32-openssh' => sub {
   subtest 'dir' => sub {
     is $actual{'.ssh'}->[0], '.ssh';
     is $actual{'.ssh'}->[1], 'd';
+    like $actual{'.ssh'}->[3], qr/^[0-9]+$/;
     is $actual{'.ssh'}->[4], '16832';
   };
   subtest 'file' => sub {
     is $actual{'.bash_history'}->[0], '.bash_history';
     is $actual{'.bash_history'}->[1], 'f';
     is $actual{'.bash_history'}->[2], '2090';
+    like $actual{'.bash_history'}->[3], qr/^[0-9]+$/;
     is $actual{'.bash_history'}->[4], '33152';
   };
 };

--- a/t/file_listing.t
+++ b/t/file_listing.t
@@ -241,4 +241,21 @@ subtest 'perms' => sub {
 
 };
 
+subtest 'win32-openssh' => sub {
+  my $txt = do {
+    open my $fh, '<', "corpus/win32-openssh.txt";
+    local $/;
+    <$fh>;
+  };
+
+  my %actual = map { $_->[0] => $_ } parse_dir($txt, undef);
+
+  subtest 'dir' => sub {
+    is_deeply $actual{'.ssh'}, ['.ssh','d',undef,'1604323020','16832'];
+  };
+  subtest 'file' => sub {
+    is_deeply $actual{'.bash_history'}, ['.bash_history','f','2090','1604332320','33152'];
+  };
+};
+
 done_testing;


### PR DESCRIPTION
Win32-OpenSSH outputs `*` for the group/other parts:

```
-rw-******    1 -        -            2090 Nov  2 16:52 .bash_history
-rw-******    1 -        -              54 Oct 29 16:07 .minttyrc
drwx******    1 -        -            4096 Nov  2 14:17 .ssh
-rw-******    1 -        -               0 Nov  2 10:00 .tig_history
-rw-******    1 -        -             890 Nov  2 14:42 .viminfo
```