### PR TITLE
do not test year 2038+ dates on systems that cannot handle them

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,8 @@ Revision history for {{$dist->name}}
   - Main git repository has now been detached from the original
     repository (originally it was a fork).  The old repository
     can be found at https://github.com/gisle/file-listing
+  - Adjust test suite to handle systems that cannot handle
+    year 2038+ dates (gh#24)
 
 6.14      2020-11-30 05:48:07 -0700
   - Production version identical to 6.12_01

--- a/t/file_listing.t
+++ b/t/file_listing.t
@@ -170,14 +170,64 @@ subtest 'apache' => sub {
       [localtime($time)]->[5] + 1900;
     };
 
+    ## hack to test the test of 2038 bug systems when
+    ## you do not have one handy.
+    #require Test2::Mock;
+    #my $mock = Test2::Mock->new( class => 'Time::Local' );
+    #$mock->around( 'timelocal' => sub {
+    #  my $orig = shift;
+    #  my(undef,undef,undef,undef,undef, $year) = @_;
+    #  die "frooble bits" if $year >= 2038;
+    #  $orig->(@_);
+    #});
+
+    my $max_year = 2500;
+
+    local $@;
+    eval {
+      require Time::Local;
+      Time::Local::timelocal(0, 30, 16, 29, 5, 2038);
+    };
+
+    if(my $error = $@)
+    {
+      diag '';
+      diag "WARNING WARNING WARNING";
+      diag '';
+      diag "Your Perl / Operating System does not support dates in 2038.";
+      diag "(probably due to 32 bit unix epoch).";
+      diag "I will skip tests with these types of dates, but you should";
+      diag "upgrade your Perl / Operating System if possible";
+      diag '';
+      diag "actual exception: $error";
+      diag '';
+      diag "WARNING WARNING WARNING";
+      $max_year = 2037;
+    }
+
     # Note: explicitly not tested are two digit years,
     # because the current behavior is probably wrong.
     # Right now we assume 9x is 199x and 0-89 is 20xx,
     # which is definitely wrong in the long term, but
     # I don't even have any examples where apache provides
     # a two digit date.
-    foreach my $year (1970..2500) {
-      is( $parse->("$year-06-29 16:30"), $year, "year = $year" );
+    foreach my $year (1970..$max_year) {
+      local $@;
+
+      my $got = eval { $parse->("$year-06-29 16:30") };
+      my $error = $@;
+      my $expected = $year;
+      my $name = "year = $year";
+
+      if($error)
+      {
+        fail($name);
+        diag "parser threw exception: $error";
+      }
+      else
+      {
+        is( $got, $expected, $name );
+      }
     }
 
   };


### PR DESCRIPTION
This code (hopefully) detects when you have a system that cannot handle Year 2038 dates (see https://en.wikipedia.org/wiki/Year_2038_problem) and skips tests that use those dates.  This allows the test suite to pass on older systems that are using 32 bit epoch.  It issues a noisy-ish warning recommending that you upgrade since modern hardware will have an upgrade path to fix this.

I wasn't able to easily reproduce this, so I set up a Test2::Mock to simulate the effects of a deficient system.  There have been a few cpantesters results that exhibit this problem so if this doesn't work hopefully i will eventually get a result.

Also updated the test that seems to fail here, and catch the exception to help in diagnostics (test will still fail if for some reason the avoidance does not work).