### PR TITLE
Add support for Windows listings with four-digit year format

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+  - Support dosftp listings with four-digit years (gh#3, gh#26)
 
 6.15      2022-04-17 04:09:58 -0600
   - Main git repository has now been detached from the original

--- a/dist.ini
+++ b/dist.ini
@@ -46,6 +46,7 @@ contributor = FWILES
 contributor = Father Chrysostomos
 contributor = Gavin Peters
 contributor = Graeme Thompson
+contributor = Grant Street Group
 contributor = Hans-H. Froehlich
 contributor = Ian Kilgore
 contributor = Jacob J

--- a/lib/File/Listing.pm
+++ b/lib/File/Listing.pm
@@ -246,10 +246,14 @@ sub line
 
     my ($date, $size_or_dir, $name, $size);
 
+    # usual format:
     # 02-05-96  10:48AM                 1415 src.slf
     # 09-10-96  09:18AM       <DIR>          sl_util
+    # alternative dos format with four-digit year:
+    # 02-05-2022  10:48AM                 1415 src.slf
+    # 09-10-2022  09:18AM       <DIR>          sl_util
     if (($date, $size_or_dir, $name) =
-        /^(\d\d-\d\d-\d\d\s+\d\d:\d\d\wM)         # Date and time info
+        /^(\d\d-\d\d-\d{2,4}\s+\d\d:\d\d\wM)      # Date and time info
          \s+                                      # Some space
          (<\w{3}>|\d+)                            # Dir or Size
          \s+                                      # Some more space

--- a/t/file_listing.t
+++ b/t/file_listing.t
@@ -241,7 +241,17 @@ subtest 'dosftp' => sub {
 09-10-96  09:18AM       <DIR>          sl_util
 EOT
 
-  ok @$list, "is 2";
+  is scalar @$list, 2, "is 2";
+  ok $list->[0][0], "src.slf";
+  ok $list->[0][1], "f";
+  ok $list->[1][1], "d";
+
+  $list = parse_dir(<<EOT, undef, 'dosftp');
+02-05-2022  10:48AM                 1415 src.slf
+09-10-2022  09:18AM       <DIR>          sl_util
+EOT
+
+  is scalar @$list, 2, "is 2";
   ok $list->[0][0], "src.slf";
   ok $list->[0][1], "f";
   ok $list->[1][1], "d";


### PR DESCRIPTION
This date format has been an option available in the Windows Server FTP service since at least 2012, and possibly elsewhere.
It is also supported by HTTP::Date as of 6.06.